### PR TITLE
Fix key indexer ResultWidget

### DIFF
--- a/contributors/lucasdibz.txt
+++ b/contributors/lucasdibz.txt
@@ -1,2 +1,0 @@
-lucasdibz
-https://aluraquiz.lucasdibz.vercel.app/

--- a/contributors/lucasdibz.txt
+++ b/contributors/lucasdibz.txt
@@ -1,0 +1,2 @@
+lucasdibz
+https://aluraquiz.lucasdibz.vercel.app/

--- a/pages/quiz.js
+++ b/pages/quiz.js
@@ -32,7 +32,7 @@ function ResultWidget({ results }) {
         </p>
         <ul>
           {results.map((result, index) => (
-            <li key={`result__${result}`}>
+            <li key={`result__${index}`}>
               #
               {index + 1}
               {' '}


### PR DESCRIPTION
key={`result__${result}` gera diversos  result__true || result__false

Alterado para {`result__${index}` para ajustar o problema de indexação do React.