### PR TITLE
Corrige seleção do input nas questões do quiz

### DIFF
--- a/pages/quiz.js
+++ b/pages/quiz.js
@@ -129,6 +129,7 @@ function QuestionWidget({
                   style={{ display: 'none' }}
                   id={alternativeId}
                   name={questionId}
+                  checked={isSelected}
                   onChange={() => setSelectedAlternative(alternativeIndex)}
                   type="radio"
                 />


### PR DESCRIPTION
Sem definir o valor do "checked" não fica possível selecionar a alternativa de mesma posição para questões seguidas.