### PR TITLE
{`result__${result}`} para result__${index}`}

### DIFF
--- a/src/screens/Quiz/index.js
+++ b/src/screens/Quiz/index.js
@@ -36,7 +36,7 @@ function ResultWidget({ results }) {
         </p>
         <ul>
           {results.map((result, index) => (
-            <li key={`result__${result}`}>
+            <li key={`result__${index}`}>
               #
               {index + 1}
               {' '}


### PR DESCRIPTION
Essa alteração vai fazer o warning sumir. Do jeito que tava, as keys estavam aparecendo sempre "result__true", da nova forma cada objeto vai ter sua key única dentro do array, do jeito que o React gosta.