### PR TITLE
Alterando regras do Eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,9 @@ module.exports = {
   ],
   rules: {
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
+    'global-require': 'off',
+    'import/prefer-default-export': 'off',
+    'no-unused-expressions': ['error', { allowTaggedTemplates: true }]
+    'react/react-in-jsx-scope': 'next-file'
   },
 };


### PR DESCRIPTION
colocando pra dá requeri global , quando o arquivo não se encontra no arquivo de importação , tipo uma imagem que queremos trazer e não esta nos arquivos . Segundo exportação de vários arquivos sem ser default . Terceiro para não precisa de reclama quando não usa uma variável, tipo styled-components quando criamos uma variante global que não usamos  e Quarto pegando o que o Paulo falou sobre toda hora ter que declara a importação do escopo do react nos arquivos . 